### PR TITLE
chore(flake/nixpkgs): `567a49d1` -> `e73de5be`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -81,11 +81,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781577229,
-        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
| Commit                                                                                         | Message                                                                                              |
| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
| [`f438cd8d`](https://github.com/NixOS/nixpkgs/commit/f438cd8d562564dfa62520b63964d90893f7b1ef) | `` nixos/doc: release note for /etc/machine-id on immutable /etc ``                                  |
| [`86a665d5`](https://github.com/NixOS/nixpkgs/commit/86a665d5b6f7ffd20638ff9c617d41204bd8ad7b) | `` nixos/etc-overlay: fix machine-id-commit on first-boot when /etc is RO ``                         |
| [`3eaafe4d`](https://github.com/NixOS/nixpkgs/commit/3eaafe4d48e3b338ff6bd8d988c370dbe05c479a) | `` nixos/etc-overlay: ship empty /etc/machine-id on immutable /etc ``                                |
| [`b236c999`](https://github.com/NixOS/nixpkgs/commit/b236c9990ee5e7e808286a589182c5924a0ef5cd) | `` terraform-providers.aminueza_minio: 3.38.0 -> 3.38.1 ``                                           |
| [`bd2cf925`](https://github.com/NixOS/nixpkgs/commit/bd2cf925d3e32e5eb591693bcf6200284b1b98f9) | `` terraform-providers.hetznercloud_hcloud: 1.64.0 -> 1.66.0 ``                                      |
| [`f824413a`](https://github.com/NixOS/nixpkgs/commit/f824413a7cb14f547bc731ce42dee53eade3c5fc) | `` frida-tools: 14.10.2 -> 14.10.4 ``                                                                |
| [`70faf259`](https://github.com/NixOS/nixpkgs/commit/70faf259f57751ec79f839f2c5078cf540fd8044) | `` zapzap: 6.5.2.1 -> 6.5.2.4 ``                                                                     |
| [`795aa7d4`](https://github.com/NixOS/nixpkgs/commit/795aa7d46c15ca37aacb84547a234423e8ebe559) | `` nerva: 1.29.0 -> 1.30.0 ``                                                                        |
| [`d8b65b87`](https://github.com/NixOS/nixpkgs/commit/d8b65b8767803d5e9bc4ba567c47b2ceb6e0d185) | `` python3Packages.xhtml2pdf: unpin reportlab ``                                                     |
| [`d0f05305`](https://github.com/NixOS/nixpkgs/commit/d0f05305e966d3caac7b10f7b2c878a06a884a03) | `` python3Packages.quack-kernels: 0.5.2 -> 0.5.3 ``                                                  |
| [`150f5208`](https://github.com/NixOS/nixpkgs/commit/150f52081dfb41993ba8718acaa7d0ada853b26f) | `` devin-cli: 2026.7.16 -> 2026.8.18 ``                                                              |
| [`ccc1c033`](https://github.com/NixOS/nixpkgs/commit/ccc1c03356edc7e713a565da1921b0e96cd5a868) | `` terraform-providers.hashicorp_aws: 6.50.0 -> 6.52.0 ``                                            |
| [`c219c29b`](https://github.com/NixOS/nixpkgs/commit/c219c29bd9086cf456e2b27122a371080497424e) | `` python3Packages.rst2pdf: unpin reportlab ``                                                       |
| [`cd43e661`](https://github.com/NixOS/nixpkgs/commit/cd43e661d4c1f3e0b2eacc400a4891837b4035ba) | `` doggo: 1.1.7 -> 1.2.0 ``                                                                          |
| [`1db3813f`](https://github.com/NixOS/nixpkgs/commit/1db3813fb2d99be36269404d85bc8268daa7c682) | `` sideband: 1.9.6 -> 1.9.7 ``                                                                       |
| [`fcda5023`](https://github.com/NixOS/nixpkgs/commit/fcda5023fe78333229029339f0c57be291452428) | `` netwatch: 0.25.7 -> 0.25.8 ``                                                                     |
| [`0acb4d2c`](https://github.com/NixOS/nixpkgs/commit/0acb4d2c47b10060a964bc447d0d311c0c890e4c) | `` python3Packages.coinbase-advanced-py: 1.8.3 -> 1.8.4 ``                                           |
| [`475404a7`](https://github.com/NixOS/nixpkgs/commit/475404a7f45b425317f5cf034e247fa3d9894256) | `` lazyworktree: 1.46.1 -> 1.47.0 ``                                                                 |
| [`5c30c61d`](https://github.com/NixOS/nixpkgs/commit/5c30c61d28ccc2ffb2ed4fc04c4771bc20ce999f) | `` libretro.play: 0-unstable-2026-06-06 -> 0-unstable-2026-06-22 ``                                  |
| [`3e5d75fd`](https://github.com/NixOS/nixpkgs/commit/3e5d75fdd3ba9034f6e9726c4c576a5c395782a6) | `` nix-scheduler-hook: 0.7.3 -> 0.8.0 ``                                                             |
| [`9c64640a`](https://github.com/NixOS/nixpkgs/commit/9c64640adae2834cb4f149ad98ad0d75240b7aaf) | `` olivetin-3k: 3000.14.0 -> 3000.15.0 ``                                                            |
| [`6446adea`](https://github.com/NixOS/nixpkgs/commit/6446adea34174a67ffff0709703ba471e89c5fc2) | `` kicad-testing-small: 10.0-2026-06-20 -> 10.0-2026-06-26 ``                                        |
| [`7f4ac054`](https://github.com/NixOS/nixpkgs/commit/7f4ac054cec3eab559584350313582cab9abd0cd) | `` typescript-go: 0-unstable-2026-06-17 -> 0-unstable-2026-06-25 ``                                  |
| [`0465ffec`](https://github.com/NixOS/nixpkgs/commit/0465ffec566c1749b0cb278af890cae9ed1d50cd) | `` scantpaper: add meta.changelog ``                                                                 |
| [`5ed9fbed`](https://github.com/NixOS/nixpkgs/commit/5ed9fbed94b95306c60ffe4e750aa6bca3402980) | `` metasploit: 6.4.138 -> 6.4.141 ``                                                                 |
| [`1c7912bb`](https://github.com/NixOS/nixpkgs/commit/1c7912bbdd9dc571e6a2112aaaaf81e3b3c95852) | `` scantpaper: 3.0.7 -> 3.0.9 ``                                                                     |
| [`2f7dbd1d`](https://github.com/NixOS/nixpkgs/commit/2f7dbd1d638bb149a1aa1026ba81f7435fb4af5b) | `` encrypted-dns-server: 0.9.20 -> 0.9.21 ``                                                         |
| [`33ea459e`](https://github.com/NixOS/nixpkgs/commit/33ea459ef59efcad4c9cf8c8011ea47519c7032a) | `` powershell-editor-services: 4.6.0 -> 4.7.0 ``                                                     |
| [`00f78a6b`](https://github.com/NixOS/nixpkgs/commit/00f78a6b8bdad4111ab7037f4cf7bd2f583f968a) | `` rymcast: drop ``                                                                                  |
| [`c7d0f5d1`](https://github.com/NixOS/nixpkgs/commit/c7d0f5d1100c75cbdd7b6c5238f4b76263226c8f) | `` efitools: Fix cross-compilation ``                                                                |
| [`abfe15ab`](https://github.com/NixOS/nixpkgs/commit/abfe15ab4e7c0bf90a071d5bf59c21fc03db310f) | `` sbsigntool: Fix cross-compilation ``                                                              |
| [`e4833fb7`](https://github.com/NixOS/nixpkgs/commit/e4833fb7f4dbfe642d169e96c703c848bcfab257) | `` python3Packages.google-cloud-run: 0.16.0 -> 0.16.1 ``                                             |
| [`13efe068`](https://github.com/NixOS/nixpkgs/commit/13efe068ab74ddac97c5e320f82f8fc0a042d995) | `` python3Packages.alibabacloud-tea-util: add structuredAttrs ``                                     |
| [`eae69d27`](https://github.com/NixOS/nixpkgs/commit/eae69d272eee252eae27dcc4619ba7b0c1d3adac) | `` python3Packages.alibabacloud-tea-util: migrate to finalAttrs ``                                   |
| [`0988e147`](https://github.com/NixOS/nixpkgs/commit/0988e147b546fbd3e88e2b75be0c41a220bdb9a4) | `` python3Packages.linode-api4: init at 5.45.0 ``                                                    |
| [`1ff982dd`](https://github.com/NixOS/nixpkgs/commit/1ff982dd2dfedf0e86312339f5debb85e45e3e47) | `` python3Packages.scaleway: init at 2.11.0 ``                                                       |
| [`08abf742`](https://github.com/NixOS/nixpkgs/commit/08abf742bca1fc63863a327d41561182c25b72bd) | `` python3Packages.scaleway-core: init at 2.11.0 ``                                                  |
| [`d920c934`](https://github.com/NixOS/nixpkgs/commit/d920c934e6621eabc709848431904f3b9bf472a2) | `` python3Packages.alibabacloud-sls20201230: init at 5.14.0 ``                                       |
| [`58c73e68`](https://github.com/NixOS/nixpkgs/commit/58c73e68bcdb5a61af119969d76a84cfd87b219f) | `` python3Packages.alibabacloud-gateway-sls: init at 0.4.2 ``                                        |
| [`6b3f3586`](https://github.com/NixOS/nixpkgs/commit/6b3f358645115f09eb34fb4092a2ca804be2c882) | `` python3Packages.alibabacloud-gateway-sls-util: init at 0.4.1 ``                                   |
| [`dfe370fb`](https://github.com/NixOS/nixpkgs/commit/dfe370fb2062488cbf4424218b4f085b1a8cbfd9) | `` python3Packages.aliyun-log-fastpb: init at 0.3.0 ``                                               |
| [`31ee7459`](https://github.com/NixOS/nixpkgs/commit/31ee745965b3e48bdd56c93f0fa54619274ba55d) | `` python3Packages.alibabacloud-oss20190517: init at 1.0.6 ``                                        |
| [`196cedd0`](https://github.com/NixOS/nixpkgs/commit/196cedd08c76c945df154b49bef14899c40b7149) | `` python3Packages.alibabacloud-gateway-oss: init at 0.0.27 ``                                       |
| [`25549174`](https://github.com/NixOS/nixpkgs/commit/2554917415e27d2c1542b76c8aa2bf4ba3fa3f20) | `` python3Packages.alibabacloud-oss-util: init at 0.0.6 ``                                           |
| [`813e41bd`](https://github.com/NixOS/nixpkgs/commit/813e41bdc69d8cf9abf9a84ed9070633dc13a370) | `` python3Packages.alibabacloud-darabonba-array: init at 0.1.0 ``                                    |
| [`e711e03b`](https://github.com/NixOS/nixpkgs/commit/e711e03b861cac530b74f460a01ce8b6d7aea7a9) | `` python3Packages.alibabacloud-darabonba-encode-util: init at 0.0.2 ``                              |
| [`91a3fcf7`](https://github.com/NixOS/nixpkgs/commit/91a3fcf77f3d2d205514d7bedfa149901c06d03e) | `` python3Packages.alibabacloud-darabonba-map: init at 0.0.1 ``                                      |
| [`fd3288a0`](https://github.com/NixOS/nixpkgs/commit/fd3288a0c01fc43bcff1c5b4b6de9854fd13e422) | `` python3Packages.alibabacloud-darabonba-signature-util: init at 0.0.4 ``                           |
| [`4adc2076`](https://github.com/NixOS/nixpkgs/commit/4adc2076a8bcb01b2b4b832619fd90d6bb327210) | `` python3Packages.alibabacloud-darabonba-string: init at 0.0.4 ``                                   |
| [`a67d6991`](https://github.com/NixOS/nixpkgs/commit/a67d6991c41744acbf359a0a0065475cac53a3a6) | `` python3Packages.alibabacloud-darabonba-time: init at 0.0.1 ``                                     |
| [`359a6b64`](https://github.com/NixOS/nixpkgs/commit/359a6b6427654ffe33484277efe9cc6fd47e87ac) | `` python3Packages.alibabacloud-tea-xml: init at 0.0.3 ``                                            |
| [`13be283f`](https://github.com/NixOS/nixpkgs/commit/13be283faee8b9feb719e25acce8a4ce9156dfb2) | `` python3Packages.alibabacloud-gateway-oss-util: init at 0.0.13 ``                                  |
| [`c49bc567`](https://github.com/NixOS/nixpkgs/commit/c49bc56732702aebceeb0925b6c84345a5c4056f) | `` python3Packages.alibabacloud-ram20150501: init at 1.2.0 ``                                        |
| [`618fd6e9`](https://github.com/NixOS/nixpkgs/commit/618fd6e93f2cbca6053eec9f02df444248ca6dbc) | `` python3Packages.alibabacloud-rds20140815: init at 13.0.1 ``                                       |
| [`7def35fe`](https://github.com/NixOS/nixpkgs/commit/7def35fe95d2a7a5b4692f15e3ab84bd0a37f785) | `` python3Packages.alibabacloud-sas20181203: init at 9.3.3 ``                                        |
| [`1687ed4d`](https://github.com/NixOS/nixpkgs/commit/1687ed4dacae087322776c72207232b849f9d71a) | `` python3Packages.alibabacloud-ecs20140526: init at 7.8.7 ``                                        |
| [`7157147c`](https://github.com/NixOS/nixpkgs/commit/7157147caf7c4d508cb3ed77bcbe7661959d2418) | `` python3Packages.alibabacloud-actiontrail20200706: init at 2.6.0 ``                                |
| [`cf8fbe92`](https://github.com/NixOS/nixpkgs/commit/cf8fbe924402c27689c106fb0519c559710395e3) | `` python3Packages.parsedmarc: 10.1.1 -> 10.2.0 ``                                                   |
| [`3b0d75a5`](https://github.com/NixOS/nixpkgs/commit/3b0d75a5541b3c8fcf48bea8284cb7043249bfd9) | `` postgresqlPackages.pg_search: 0.24.0 -> 0.24.1 ``                                                 |
| [`0cdbe4fa`](https://github.com/NixOS/nixpkgs/commit/0cdbe4fa4a89775c19dc97342e1f14e1ad574664) | `` osu-lazer: 2026.620.0 -> 2026.624.0 ``                                                            |
| [`2237f4db`](https://github.com/NixOS/nixpkgs/commit/2237f4dbf6d70dd6e295cd5ace2b490ade23932b) | `` osu-lazer-bin: 2026.620.0 -> 2026.624.0 ``                                                        |
| [`900dfaee`](https://github.com/NixOS/nixpkgs/commit/900dfaee6f4817df032f2dafdbeb61c30aba61a5) | `` treewide: remove azahi from maintainers ``                                                        |
| [`7965df47`](https://github.com/NixOS/nixpkgs/commit/7965df472f40ff070069d76455fb9c62656993c1) | `` maintainers: update azahi ``                                                                      |
| [`d0c44595`](https://github.com/NixOS/nixpkgs/commit/d0c4459538416fdfe49f89fdbb99108477de2571) | `` servarr-ffmpeg: 5.1.4 -> 5.1.10 ``                                                                |
| [`ba69f959`](https://github.com/NixOS/nixpkgs/commit/ba69f95928184ab80e2f8fd6bd7534c633f1364c) | `` ungoogled-chromium: 149.0.7827.155-1 -> 149.0.7827.196-1 ``                                       |
| [`22787823`](https://github.com/NixOS/nixpkgs/commit/2278782383e019961cb131bdea2ca74942de5d1a) | `` vimPlugins.cole-nvim: init at 0-unstable-2026-05-29 ``                                            |
| [`b6cd65fa`](https://github.com/NixOS/nixpkgs/commit/b6cd65fa3055fb731bc61f74dc68f7f6009814a4) | `` codebase-memory-mcp: init at 0.8.1 ``                                                             |
| [`d305525e`](https://github.com/NixOS/nixpkgs/commit/d305525e4b31ccc3ded6ea6c426e150e7adf7429) | `` gomuks-web: remove `libheif` patches ``                                                           |
| [`ce344f2b`](https://github.com/NixOS/nixpkgs/commit/ce344f2ba3b116055aa6cd46a5b764cd69831573) | `` matrix-alertmanager-receiver: 2026.6.10 -> 2026.6.17 ``                                           |
| [`920a8c14`](https://github.com/NixOS/nixpkgs/commit/920a8c146a1d7ab2232e1fadc7246028a85c6e18) | `` reticulated: init at 1.0.2 ``                                                                     |
| [`542f995a`](https://github.com/NixOS/nixpkgs/commit/542f995a766850ecb2a200a566b5a7bee3cf6f5f) | `` ispc: 1.30.0 -> 1.31.0 ``                                                                         |
| [`1bac4653`](https://github.com/NixOS/nixpkgs/commit/1bac46539b82df6bd71a13cd2c177b2fa9f301c6) | `` nix-search-tv: 2.2.7 -> 2.2.8 ``                                                                  |
| [`8a0fe6c0`](https://github.com/NixOS/nixpkgs/commit/8a0fe6c094daf889f28687346d9e1e646e4e6a15) | `` rainfrog: 0.3.18 -> 0.3.19 ``                                                                     |
| [`fd056499`](https://github.com/NixOS/nixpkgs/commit/fd0564999702c75198f1afb84109b856f9684e27) | `` python3Packages.alibabacloud-cs20151215: init at 7.0.0 ``                                         |
| [`d8adca4d`](https://github.com/NixOS/nixpkgs/commit/d8adca4d3353138ae18f051122d0fe957654bef4) | `` servo: 0.2.0 -> 0.3.0 ``                                                                          |
| [`ab2fe2ce`](https://github.com/NixOS/nixpkgs/commit/ab2fe2ce89aa09b8f61a4ac0c5189817a8bf683d) | `` maintainers/github-teams.json: Automated sync ``                                                  |
| [`5cae0dc6`](https://github.com/NixOS/nixpkgs/commit/5cae0dc6f170f4f1641d7dbe4e2275ad0f3ff638) | `` python3Packages.alibabacloud-gateway-spi: migrate to finalAttrs ``                                |
| [`712c83a9`](https://github.com/NixOS/nixpkgs/commit/712c83a9363d117f04049be0af189a31e1a71988) | `` python3Packages.alibabacloud-sts20150401: init at 1.2.0 ``                                        |
| [`ce675f57`](https://github.com/NixOS/nixpkgs/commit/ce675f57a25b195cdcf47989d0467c3081680b54) | `` mistral-vibe: 2.17.1 -> 2.18.0 ``                                                                 |
| [`6ca6c80d`](https://github.com/NixOS/nixpkgs/commit/6ca6c80d7ff883b3fe80375bc48b336d408712e7) | `` tuicr: format ``                                                                                  |
| [`1b9ef0d0`](https://github.com/NixOS/nixpkgs/commit/1b9ef0d030636ac190753e751d210e67640fc35b) | `` tuicr: fix build ``                                                                               |
| [`5380f881`](https://github.com/NixOS/nixpkgs/commit/5380f881fbb5c6c45ed6d757adfb786c613adce3) | `` libtsm: 4.5.0 -> 4.6.0 ``                                                                         |
| [`cfb765a8`](https://github.com/NixOS/nixpkgs/commit/cfb765a8661a80795c661180ac68d3aadca34d58) | `` tuicr: init at 0.18.0 ``                                                                          |
| [`8f33e42d`](https://github.com/NixOS/nixpkgs/commit/8f33e42dbc03eba8ccf440f159b20b6c7f3ff302) | `` sbom-utility: 0.19.1 -> 0.19.2 ``                                                                 |
| [`ed69fa42`](https://github.com/NixOS/nixpkgs/commit/ed69fa421684474df07b608f051c84e8b9fa795d) | `` python3Packages.alibabacloud-vpc20160428: init at 7.1.2 ``                                        |
| [`b9f88762`](https://github.com/NixOS/nixpkgs/commit/b9f887622c936bfac7516a1ecfa3c2030368c15c) | `` pretix.plugins.mollie: 2.5.5 -> 2.5.6 ``                                                          |
| [`a0a8146f`](https://github.com/NixOS/nixpkgs/commit/a0a8146f2d4269476aace34499dcb03e706b2536) | `` pretix.plugins.pages: 1.6.3 -> 1.6.4 ``                                                           |
| [`8efed986`](https://github.com/NixOS/nixpkgs/commit/8efed986532110378370d6510a7584fc297b3f5c) | `` pretix: 2026.5.1 -> 2026.5.2 ``                                                                   |
| [`bc046662`](https://github.com/NixOS/nixpkgs/commit/bc0466622366a8668d85e8bdff9ac98c9109f4ff) | `` python3Packages.alibabacloud-tea-openapi: 0.4.2 -> 0.4.4 ``                                       |
| [`3c0f5b03`](https://github.com/NixOS/nixpkgs/commit/3c0f5b0330648b2d27815c27440f8b2c95bd9b36) | `` python3Packages.alibabacloud-tea-openapi: init at 0.4.2 ``                                        |
| [`a494aad8`](https://github.com/NixOS/nixpkgs/commit/a494aad88aefe2e05a04f13434eed0e859bc95e3) | `` tmux-mem-cpu-load: 3.8.2 -> 3.8.3 ``                                                              |
| [`32d8b8ee`](https://github.com/NixOS/nixpkgs/commit/32d8b8ee6d117ef534ab4c04e84e7b894b8e9825) | `` vdrPlugins.softhddevice: 2.4.8 -> 2.5.0 ``                                                        |
| [`b0edce3e`](https://github.com/NixOS/nixpkgs/commit/b0edce3edd381f783762afba3f9fb40bc661de71) | `` python3Packages.darabonba-core: init at 1.0.7 ``                                                  |
| [`7dda7a5b`](https://github.com/NixOS/nixpkgs/commit/7dda7a5bf9a1b7f8346fcd1b5df8f973e4651705) | `` libretro.dosbox-pure: 0-unstable-2026-06-16 -> 0-unstable-2026-06-26 ``                           |
| [`2e44e86f`](https://github.com/NixOS/nixpkgs/commit/2e44e86fdb57e4b1702e7693cf56c6d6503a68d1) | `` hmcl: 3.15.1 -> 3.15.2 ``                                                                         |
| [`7c024246`](https://github.com/NixOS/nixpkgs/commit/7c024246a26c56994e5a77192a60a5ece198826a) | `` kubernetes-helm: 4.2.1 -> 4.2.2 ``                                                                |
| [`040ef46d`](https://github.com/NixOS/nixpkgs/commit/040ef46d93a9b7731160fafa0c88c05eebf8dbb2) | `` sonarr: 4.0.17.2952 -> 4.0.18.2971 ``                                                             |
| [`bcc95d4b`](https://github.com/NixOS/nixpkgs/commit/bcc95d4b15c571bf1e2afc10db5d2afc8e036721) | `` worktrunk: add nushell completions ``                                                             |
| [`b2b422e9`](https://github.com/NixOS/nixpkgs/commit/b2b422e9c184d20c7e1a5744ad00d5b3bda052b4) | `` python3Packages.scikit-base: 1.0.1 -> 1.0.2 ``                                                    |
| [`f26c0932`](https://github.com/NixOS/nixpkgs/commit/f26c0932b3872f0a9879a20e236b21e654e321d5) | `` python3Packages.sabctools: 9.4.1 -> 9.5.0 ``                                                      |
| [`8a6c059d`](https://github.com/NixOS/nixpkgs/commit/8a6c059de9c75298da284239c11da17179763a0e) | `` gotosocial: 0.21.2 -> 0.21.3 ``                                                                   |
| [`96435d70`](https://github.com/NixOS/nixpkgs/commit/96435d701a8a5bc689251a003dab4ec723225f62) | `` claude-agent-acp: 0.45.1 -> 0.52.0 ``                                                             |
| [`716b0b34`](https://github.com/NixOS/nixpkgs/commit/716b0b3414e635dad323b0917d529fca8ad5fe7a) | `` vscode-extensions.tuttieee.emacs-mcx: 0.110.9 -> 0.110.11 ``                                      |
| [`c9d95543`](https://github.com/NixOS/nixpkgs/commit/c9d955430e632273a2383b5472917e7cbe303989) | `` memtier-benchmark: 2.4.2 -> 2.4.3 ``                                                              |
| [`63ab6eb1`](https://github.com/NixOS/nixpkgs/commit/63ab6eb164e21b21db245aace4bac2af4a128bf5) | `` libretro.gambatte: 0-unstable-2026-06-14 -> 0-unstable-2026-06-19 ``                              |
| [`6c7195c3`](https://github.com/NixOS/nixpkgs/commit/6c7195c38a32b6b4a1f82943dcd43049ee0f2036) | `` aptly: 1.6.2 -> 1.6.3 ``                                                                          |
| [`ae81b5a0`](https://github.com/NixOS/nixpkgs/commit/ae81b5a03e04bbb9ea26f85cbeaae3877f60e841) | `` python3Packages.acquire: 3.21 -> 3.22 ``                                                          |
| [`adb767f0`](https://github.com/NixOS/nixpkgs/commit/adb767f0576d9b90158f9c5951df0030e5963197) | `` python3Packages.reproject: 0.20.0 -> 0.21.0 ``                                                    |
| [`a742480e`](https://github.com/NixOS/nixpkgs/commit/a742480e9f9d825f60986b1bce8f7d9ebffb7888) | `` maintainers/test-driver: make maintainer-team github-based and add owners, rename from 'tests' `` |
| [`2b428514`](https://github.com/NixOS/nixpkgs/commit/2b428514e551b09ba15f1dd9ea76c1b40ee801df) | `` linux: forward features into passthru ``                                                          |
| [`d0352680`](https://github.com/NixOS/nixpkgs/commit/d035268053ca9b7a37e48257cb138c5a82df613e) | `` libretro.swanstation: 0-unstable-2026-06-14 -> 0-unstable-2026-06-25 ``                           |
| [`04a30ff6`](https://github.com/NixOS/nixpkgs/commit/04a30ff621766b17b0b6bc4cea129d851160b197) | `` python3Packages.requirements-parser: 0.13.0 -> 0.13.1 ``                                          |
| [`cf8b2c28`](https://github.com/NixOS/nixpkgs/commit/cf8b2c280a9e0afd3692fe514e672eaa7a1a3aaa) | `` geeqie: 2.7 -> 2.8 ``                                                                             |
| [`0c1c3d48`](https://github.com/NixOS/nixpkgs/commit/0c1c3d48139703764cb5415b585313ef8b15d0fe) | `` ci/github-script/merge: share reviews fetch with bot.js, drop events ``                           |
| [`6f9325fb`](https://github.com/NixOS/nixpkgs/commit/6f9325fb5dbf965b2078cba8a5ca4ad285e8f0af) | `` ci/github-script/merge: clarify Auto Merge follow-up tip ``                                       |
| [`2aed8750`](https://github.com/NixOS/nixpkgs/commit/2aed8750428c136f9bec9f899c94cb41cc9d3837) | `` snx-rs: 6.1.1 -> 6.1.2 ``                                                                         |
| [`b94b44d3`](https://github.com/NixOS/nixpkgs/commit/b94b44d3f9e0d7d021dc4d550d2dd0185da47489) | `` ci/github-script/merge: refuse merge when a committer has requested changes ``                    |
| [`da97bf84`](https://github.com/NixOS/nixpkgs/commit/da97bf84234657e6fdde8fabd8720eceb685d4f4) | `` ci/github-script/merge: skip auto-merge when CI has already failed ``                             |
| [`613167a4`](https://github.com/NixOS/nixpkgs/commit/613167a467a6bea2db99c732b4b9b5fc8ac1a432) | `` go-hass-agent: 14.12.0 -> 14.14.1 ``                                                              |
| [`bc0b3d21`](https://github.com/NixOS/nixpkgs/commit/bc0b3d21e1a4fb9aba3a6c6e5de109ceac30ef43) | `` jfbview: 0.6.1 -> 0.7.0 ``                                                                        |
| [`46755964`](https://github.com/NixOS/nixpkgs/commit/467559641c932aa88b41ef1acd20fb235eedb83a) | `` mimir: 3.1.1 -> 3.1.2 ``                                                                          |
| [`da9066d8`](https://github.com/NixOS/nixpkgs/commit/da9066d8004c18987294acb9193654e43f0ad147) | `` python3Packages.wand: 0.7.1 -> 0.7.2 ``                                                           |
| [`28027ad4`](https://github.com/NixOS/nixpkgs/commit/28027ad48ee07aab54a59d33d94479324af503e3) | `` kluctl: 2.27.0 -> 2.28.2 ``                                                                       |
| [`bfe759a7`](https://github.com/NixOS/nixpkgs/commit/bfe759a7596b93a5fde94a197dcf190b08c49334) | `` nextcloud33: 33.0.5 -> 33.0.6 ``                                                                  |
| [`dd9d37cb`](https://github.com/NixOS/nixpkgs/commit/dd9d37cbdce538698a71411804ff439f0b999a7f) | `` nextcloud32: 32.0.11 -> 32.0.12 ``                                                                |
| [`1abbb5ed`](https://github.com/NixOS/nixpkgs/commit/1abbb5ed9ebea848369a808b07e9ef244bff3cc5) | `` python3Packages.google-cloud-vision: 3.14.0 -> 3.15.0 ``                                          |
| [`921383b2`](https://github.com/NixOS/nixpkgs/commit/921383b2ceaea9d9f4909e95b84f28ecd7f9071b) | `` nixos/journald-{gateway,remote}: remove TLS support ``                                            |
| [`9247d13e`](https://github.com/NixOS/nixpkgs/commit/9247d13ebfb15eed582dc49a7ae168aedb66fb06) | `` python3Packages.beets-alternatives: fix tests with upstream patch ``                              |
| [`5f925d54`](https://github.com/NixOS/nixpkgs/commit/5f925d54e34935056037595ce8abbd7c0f90a7d7) | `` python3Packages.beets-filetote: 1.3.5 -> 1.3.6 ``                                                 |
| [`b8e9c738`](https://github.com/NixOS/nixpkgs/commit/b8e9c738605a5c248ddeeeab7d7bab45fe2f0e79) | `` python3Packages.nats-py: disable failing test ``                                                  |
| [`bc081a14`](https://github.com/NixOS/nixpkgs/commit/bc081a146c5e78a621812fd60fbb8562b797abf4) | `` python3Packages.beets-filetote: remove unused pytest argument ``                                  |
| [`59a92f1a`](https://github.com/NixOS/nixpkgs/commit/59a92f1a19522afa0086ddeb74f883bde4e74b6f) | `` python3Packages.beets: 2.11.0 -> 2.12.0 ``                                                        |
| [`17044800`](https://github.com/NixOS/nixpkgs/commit/17044800a310d9620d480f5b817da598ffc36be9) | `` procs: 0.14.11 -> 0.14.12 ``                                                                      |
| [`66602d0d`](https://github.com/NixOS/nixpkgs/commit/66602d0d6d396a3509f850fffe85437e0055ebbc) | `` sumo: 1.27.0 -> 1.27.1 ``                                                                         |
| [`0a149b71`](https://github.com/NixOS/nixpkgs/commit/0a149b71d6c9df341de767008671db7e81ad3922) | `` atlauncher: 3.4.40.4 -> 3.4.41.0 ``                                                               |
| [`3745a9eb`](https://github.com/NixOS/nixpkgs/commit/3745a9ebfc8b0782084a570efe1cb36985313eae) | `` yocto-cooker: init at 1.5.0 ``                                                                    |
| [`f1aaf708`](https://github.com/NixOS/nixpkgs/commit/f1aaf7083327a9ec9fe0d2cacd4f8bd66e2a3c12) | `` python3Packages.nats-py: migrate to finalAttrs ``                                                 |
| [`af27e3c5`](https://github.com/NixOS/nixpkgs/commit/af27e3c59b0e1e8a132fa3303734de32038d9d3f) | `` python3Packages.nats-py: 2.12.0 -> 2.15.0 ``                                                      |
| [`63a63f3a`](https://github.com/NixOS/nixpkgs/commit/63a63f3aec71a97d2cbee13462bcc5da3e33b71a) | `` spirit: 0.14.0 -> 0.15.1 ``                                                                       |
| [`66cd3515`](https://github.com/NixOS/nixpkgs/commit/66cd3515f71744b9ec614c1328eb898da547ed79) | `` nixos/tests/glusterfs: cover group presets and glusterfind hook ``                                |
| [`335d28d4`](https://github.com/NixOS/nixpkgs/commit/335d28d40634e4ec5574e231e76d7663756dd297) | `` anytype-cli: 0.3.5 -> 0.3.6 ``                                                                    |
| [`75c8a921`](https://github.com/NixOS/nixpkgs/commit/75c8a921827666d9b6e3e18b830a4143d577fb36) | `` python3Packages.lxmf: use `reticulum` license ``                                                  |
| [`8e99b441`](https://github.com/NixOS/nixpkgs/commit/8e99b441b3ea8c181479461a1182df5ed698c0b8) | `` python3Packages.rns: use `reticulum` license ``                                                   |
| [`ba44c4a4`](https://github.com/NixOS/nixpkgs/commit/ba44c4a4befd37f244ba28c341d4c20678779a49) | `` licenses: add `Reticulum License` ``                                                              |
| [`75ac5e48`](https://github.com/NixOS/nixpkgs/commit/75ac5e48935a724fcf24bccdef37ce6d0a35c9e3) | `` python3Packages.torchtune: fix tests with mlflow 3.14 ``                                          |
| [`c304ec58`](https://github.com/NixOS/nixpkgs/commit/c304ec5834c86609933dfc747a2e3c65971caaf1) | `` python3Packages.mmengine: fix tests with mlflow 3.14 ``                                           |
| [`2659effc`](https://github.com/NixOS/nixpkgs/commit/2659effcbfe8921c29d233ab53677ec6ac6afe30) | `` pdns: 5.1.1 -> 5.1.2 ``                                                                           |
| [`ee207879`](https://github.com/NixOS/nixpkgs/commit/ee20787914a09bae38369609c8c30ca8e5624d88) | `` python3Packages.nomadnet: 1.2.0 -> 1.2.6 ``                                                       |
| [`03e732eb`](https://github.com/NixOS/nixpkgs/commit/03e732eb53b161cd7923a2f1d3b1296327d0cf57) | `` sing-box: 1.13.13 -> 1.13.14 ``                                                                   |
| [`ebec5565`](https://github.com/NixOS/nixpkgs/commit/ebec5565bacb86332463457e779a0dbb9169607f) | `` python3Packages.lookyloo-models: 0.2.8 -> 0.2.9 ``                                                |
| [`8a5e9c23`](https://github.com/NixOS/nixpkgs/commit/8a5e9c23acfb32da3aa1affcf11abee7cd463e19) | `` python3Packages.checkdmarc: 5.17.1 -> 5.17.3 ``                                                   |
| [`ed1ec50d`](https://github.com/NixOS/nixpkgs/commit/ed1ec50d689ff01d0e96969e891a02bc8a7966c2) | `` python3Packages.groq: 1.4.0 -> 1.5.0 ``                                                           |
| [`825178c8`](https://github.com/NixOS/nixpkgs/commit/825178c83b6105299b086f53c15cf39b353fe336) | `` python3Packages.frigidaire: 0.18.46 -> 0.18.47 ``                                                 |
| [`35875f69`](https://github.com/NixOS/nixpkgs/commit/35875f69a4e2aa1ae57688c871dfbaddd50925e7) | `` python3Packages.fastgit: 0.0.4 -> 0.0.5 ``                                                        |
| [`96636e9a`](https://github.com/NixOS/nixpkgs/commit/96636e9a76f0a7d0185ba03368d2e147d3d1af6b) | `` python3Packages.apiflask: 3.1.0 -> 3.1.1 ``                                                       |
| [`a6b43b3e`](https://github.com/NixOS/nixpkgs/commit/a6b43b3ea54cafe26da371f3adb7700515211a8a) | `` faas-cli: 0.18.9 -> 0.18.10 ``                                                                    |
| [`a2391261`](https://github.com/NixOS/nixpkgs/commit/a23912610f184362dbd6338618263087e99b6a13) | `` spedread: 2.8.0 -> 2.8.1 ``                                                                       |
| [`af32b5d6`](https://github.com/NixOS/nixpkgs/commit/af32b5d6aa89e1c116eb1786f1f874f34e94a392) | `` tmc-cli: 1.1.2 -> 1.1.3 ``                                                                        |
| [`39e152cd`](https://github.com/NixOS/nixpkgs/commit/39e152cdbf81fe552a1cc478fdc050ef39306eb1) | `` h2o: make Brotli optional ``                                                                      |
| [`6d2f7086`](https://github.com/NixOS/nixpkgs/commit/6d2f708632caf9ef7988931f3a2a435d670787ba) | `` h2o: 2.3.0-rolling-2026-06-24 → 2.3.0-rolling-2026-06-25 ``                                       |
| [`a49bf4a5`](https://github.com/NixOS/nixpkgs/commit/a49bf4a521dcd81c3c4437a4f20c31d180933b2b) | `` h2o: makeWrapper → makeBinaryWrapper ``                                                           |
| [`47cc1443`](https://github.com/NixOS/nixpkgs/commit/47cc1443c3f48206f7fbae8a4c5c334caf692ffb) | `` qlever: 0.5.47 -> 0.5.48 ``                                                                       |
| [`bc00d256`](https://github.com/NixOS/nixpkgs/commit/bc00d2562d0095193d1707c9a4a382fa059458f6) | `` python3Packages.linearomdels: reduce openmp threads during tests ``                               |
| [`d2b1d30e`](https://github.com/NixOS/nixpkgs/commit/d2b1d30e061d4bed4615295b3a226e3807a7f5e4) | `` nodejs_26: 26.3.1 -> 26.4.0 ``                                                                    |
| [`8e4f6c07`](https://github.com/NixOS/nixpkgs/commit/8e4f6c078d1bc0d813a6e6017ce4cfccbd8cc373) | `` python3Packages.fusepy: skip imports check on darwin ``                                           |
| [`56913ae7`](https://github.com/NixOS/nixpkgs/commit/56913ae775f990b0bc49730e5fad21c64942c917) | `` python3Packages.rq: disable racy test ``                                                          |
| [`d31f4a19`](https://github.com/NixOS/nixpkgs/commit/d31f4a19992cc47ada8e7a1961aa302e810e7abb) | `` ctx7: 0.5.2 -> 0.5.3 ``                                                                           |
| [`5cf9a3fb`](https://github.com/NixOS/nixpkgs/commit/5cf9a3fb93ecd4267557a116c3f94e1f50bebaf9) | `` niks3: 1.6.1 -> 1.7.0 ``                                                                          |
| [`45906568`](https://github.com/NixOS/nixpkgs/commit/45906568b22ea91b80ac4a74da6fcd2e33560bae) | `` rocqPackages.hierarchy-builder: 1.10.2 -> 1.10.3 ``                                               |
| [`418a30d3`](https://github.com/NixOS/nixpkgs/commit/418a30d3e87d51384b84538953e3c18337225efc) | `` matterircd: 0.29.0 -> 0.30.0 ``                                                                   |
| [`145397a6`](https://github.com/NixOS/nixpkgs/commit/145397a6c50b247e9f6198ec53b440047a6e309c) | `` palemoon-bin: 34.3.0.1 -> 34.3.1 ``                                                               |
| [`2f707eb5`](https://github.com/NixOS/nixpkgs/commit/2f707eb5586b6bd598e00671a906ef975ededaa7) | `` makemkv: 1.18.3 -> 1.18.4 ``                                                                      |
| [`deb15e0a`](https://github.com/NixOS/nixpkgs/commit/deb15e0aff2d0aa1d642b359c7964828e0118614) | `` ananicy-rules-cachyos: 0-unstable-2026-06-15 -> 0-unstable-2026-06-24 ``                          |
| [`ef31608d`](https://github.com/NixOS/nixpkgs/commit/ef31608d466de7e45924ee1e9302fdd1ea962393) | `` python3Packages.claude-agent-sdk: 0.2.108 -> 0.2.110 ``                                           |
| [`be27c3fc`](https://github.com/NixOS/nixpkgs/commit/be27c3fc745a1777e9c058e2bf61f3e937f36301) | `` vex-tui: add meta.mainProgram ``                                                                  |
| [`73608b95`](https://github.com/NixOS/nixpkgs/commit/73608b95c6967281c498537451007340cc737c77) | `` python3Packages.pydrawise: migrate to finalAttrs ``                                               |
| [`d65d083a`](https://github.com/NixOS/nixpkgs/commit/d65d083aa7a566062421a9d9a05d5d9b400e8dd7) | `` tmuxPlugins.dracula: 3.2.0 -> 3.3.0 ``                                                            |
| [`ef628ee7`](https://github.com/NixOS/nixpkgs/commit/ef628ee78fa7f0f28895aa19d11e6c61ddefca92) | `` tmuxPlugins.*: set passthru.updateScript ``                                                       |
| [`b16254b3`](https://github.com/NixOS/nixpkgs/commit/b16254b39d3367ee0adddf40d50ea51ab131a729) | `` mtail: 3.3.2 -> 3.4.0 ``                                                                          |
| [`df9ad010`](https://github.com/NixOS/nixpkgs/commit/df9ad010b135bf9c22b338530449fcb2f0217f42) | `` python3Packages.google-cloud-workstations: 0.8.0 -> 0.8.1 ``                                      |
| [`b83e853c`](https://github.com/NixOS/nixpkgs/commit/b83e853c2b86cbfe003ab649cce8e9caba3df75b) | `` python3Packages.iamdata: 0.1.202606241 -> 0.1.202606251 ``                                        |
| [`5e4d57e6`](https://github.com/NixOS/nixpkgs/commit/5e4d57e664b9cb7b9d537839b7960c1ad6451937) | `` python3Packages.tencentcloud-sdk-python: 3.1.121 -> 3.1.122 ``                                    |
| [`b6cc664b`](https://github.com/NixOS/nixpkgs/commit/b6cc664b526e8fc0967bd29a9c5d38453ea9a46b) | `` python3Packages.tencentcloud-sdk-python: 3.1.120 -> 3.1.121 ``                                    |
| [`5d15b93a`](https://github.com/NixOS/nixpkgs/commit/5d15b93a2194e69a583a90d4022692bee7a7808c) | `` grafanaPlugins.grafana-googlesheets-datasource: 2.5.0 -> 2.5.1 ``                                 |
| [`cd65877b`](https://github.com/NixOS/nixpkgs/commit/cd65877bf57c0f6ba19da1578aa1371197990f54) | `` nixos/prometheus-exporters/mail-tlsa-check: init ``                                               |
| [`b2be0d99`](https://github.com/NixOS/nixpkgs/commit/b2be0d99ea0f88b8251f7133218a77bfe38dc8f1) | `` mail-tlsa-check-exporter: init at 0-unstable-2025-06-12 ``                                        |
| [`1e4dfdfe`](https://github.com/NixOS/nixpkgs/commit/1e4dfdfec8fc0eaf6431d33afbdddde2dd696253) | `` nrpl: drop ``                                                                                     |
| [`d1be3d60`](https://github.com/NixOS/nixpkgs/commit/d1be3d60e2488f9b73a7171da9cb259e775e46ea) | `` Revert "kdePackages.plasma-workspace: backport patch for Qt 6.11.1 regression" ``                 |
| [`1619f140`](https://github.com/NixOS/nixpkgs/commit/1619f1403ee25e0ca4ed4973cdbeff8a0edb863d) | `` python3Packages.pydrawise: 2026.4.0 -> 2026.6.0 ``                                                |
| [`bd022e3c`](https://github.com/NixOS/nixpkgs/commit/bd022e3c5a54b5f05eeb92cd02a82d2fc76a65f2) | `` nixos/apparmor: load bpf last unconditionally ``                                                  |
| [`69376d60`](https://github.com/NixOS/nixpkgs/commit/69376d6061485b164a91b56d2293aa42c84dffa0) | `` fishPlugins.hydro: add update script ``                                                           |
| [`e0cd3178`](https://github.com/NixOS/nixpkgs/commit/e0cd3178e72e5e537265077a51f1ddb5fc05e7ac) | `` fishPlugins.hydro: add HigherOrderLogic as maintainer ``                                          |
| [`9dc02ded`](https://github.com/NixOS/nixpkgs/commit/9dc02ded9950f26f01aca93ced914c8052c1bb77) | `` newelle: add michaelAllen as maintainer ``                                                        |
| [`c4ad9042`](https://github.com/NixOS/nixpkgs/commit/c4ad9042edb99fd29ed21768a7836b7f81352346) | `` maintainers: add michaelAllen ``                                                                  |
| [`c7410cbd`](https://github.com/NixOS/nixpkgs/commit/c7410cbde4e06c7baf96c19c74633702ffb1f79a) | `` oyui: init at 0.2.1 ``                                                                            |
| [`0eaf2dd6`](https://github.com/NixOS/nixpkgs/commit/0eaf2dd6bd7827463977f16a06aca7a017bd9d4c) | `` perl5Packages.ModuleCPANTSAnalyse: skip failing test ``                                           |
| [`c8342acc`](https://github.com/NixOS/nixpkgs/commit/c8342acc2aad9c3050a14bab6ed2fc39d13fd5ab) | `` vscode-extensions.anthropic.claude-code: 2.1.187 -> 2.1.191 ``                                    |
| [`0108c1cc`](https://github.com/NixOS/nixpkgs/commit/0108c1ccb5689e4616e941a458856efa39492081) | `` claude-code: 2.1.187 -> 2.1.191 ``                                                                |
| [`fe3a1425`](https://github.com/NixOS/nixpkgs/commit/fe3a142521335e3ae593889ba7733713bcb29fcf) | `` nixos/incus: remove named profile ``                                                              |
| [`458579d4`](https://github.com/NixOS/nixpkgs/commit/458579d4f38572654974b630a9c78c8d43ee7b8d) | `` zapret2: 1.0.1 -> 1.0.2 ``                                                                        |
| [`d18c0cfb`](https://github.com/NixOS/nixpkgs/commit/d18c0cfb3373f585547fe8756207438286a72fbd) | `` yamlscript: 0.2.20 -> 0.2.23 ``                                                                   |
| [`c04d03a6`](https://github.com/NixOS/nixpkgs/commit/c04d03a64693a896dd6cc0c747df5d699a2e2edc) | `` thunderbird-latest-unwrapped: 151.0.1 -> 152.0 ``                                                 |
| [`1ecf01ef`](https://github.com/NixOS/nixpkgs/commit/1ecf01ef56c262de9e2f97ace308bef85c0e836c) | `` skills: 1.5.11 -> 1.5.13 ``                                                                       |
| [`0ba07399`](https://github.com/NixOS/nixpkgs/commit/0ba073993091df2dcc540cd9402c9a8db770bdc5) | `` stevenblack-blocklist: 3.16.89 -> 3.16.91 ``                                                      |
| [`6c0622e3`](https://github.com/NixOS/nixpkgs/commit/6c0622e38060bb5e58e518b800005cc99799b548) | `` tabiew: 0.13.1 -> 0.14.0 ``                                                                       |
| [`f86c05d7`](https://github.com/NixOS/nixpkgs/commit/f86c05d70d7e1130bb55fc3d771c074f6f14e431) | `` terraform-providers.ubiquiti-community_unifi: 0.52.4 -> 0.53.0 ``                                 |
| [`46f6c26b`](https://github.com/NixOS/nixpkgs/commit/46f6c26b1558e1d357279249e3b2ffdb33d6f315) | `` python3Packages.frida-python: 17.9.11 -> 17.15.3 ``                                               |
| [`10c06806`](https://github.com/NixOS/nixpkgs/commit/10c068066e87ee97b34ea60d1d72b6ef6dbfef1b) | `` sirius: enable strictDeps, __structuredAttrs ``                                                   |
| [`26bf1a76`](https://github.com/NixOS/nixpkgs/commit/26bf1a7697fabfbf07787931a1c052e9dd79b2d4) | `` attic-client: Use nixVersions.nix_2_34 ``                                                         |
| [`d1aec259`](https://github.com/NixOS/nixpkgs/commit/d1aec25993af52b6362db008002034a64704edb5) | `` libretro.genesis-plus-gx: 0-unstable-2026-06-12 -> 0-unstable-2026-06-19 ``                       |
| [`0c575c87`](https://github.com/NixOS/nixpkgs/commit/0c575c875524995da8dc788394c123a6a3fc1c7b) | `` rusthound-ce: 2.4.7 -> 2.4.9 ``                                                                   |
| [`caa1970c`](https://github.com/NixOS/nixpkgs/commit/caa1970c5b9a2892e0ed792c18cfcdcc71108d37) | `` python3Packages.google-cloud-translate: 3.26.0 -> 3.27.0 ``                                       |
| [`dc27f0ca`](https://github.com/NixOS/nixpkgs/commit/dc27f0ca862868c0978aa64c33a7f22aba944b9e) | `` python3Packages.spotipyfree: 1.9.12 -> 1.9.13 ``                                                  |
| [`9bfe2ad8`](https://github.com/NixOS/nixpkgs/commit/9bfe2ad8062c24e4aeab2540711691705e192006) | `` rucio: 40.3.0 -> 40.4.0 ``                                                                        |
| [`208bd37d`](https://github.com/NixOS/nixpkgs/commit/208bd37d2d105131ebd94512096e526b8b8a0291) | `` python3Packages.adafruit-platformdetect: 3.88.0 -> 3.89.1 ``                                      |
| [`ee007448`](https://github.com/NixOS/nixpkgs/commit/ee0074480b01bc2ca3b64497963ed5c17dd9a365) | `` terraform-providers.hashicorp_google-beta: 7.36.0 -> 7.38.0 ``                                    |
| [`71c27787`](https://github.com/NixOS/nixpkgs/commit/71c27787e32b7d66502deed0c438792442df3560) | `` terraform-providers.aiven_aiven: 4.58.0 -> 4.59.0 ``                                              |
| [`a7b4a549`](https://github.com/NixOS/nixpkgs/commit/a7b4a5492cd28ea6dcc24a9df697036d3eb4fbdc) | `` cargo-tarpaulin: 0.35.4 -> 0.35.5 ``                                                              |
| [`48a8ded7`](https://github.com/NixOS/nixpkgs/commit/48a8ded7480c0f3459bc7ee7759434c4b1fdda4c) | `` cargo-zigbuild: 0.22.3 -> 0.23.0 ``                                                               |
| [`36b683a6`](https://github.com/NixOS/nixpkgs/commit/36b683a6df9a8068e987828e3039910792b428da) | `` cp2k: enable strictDeps, __structuredAttrs ``                                                     |
| [`2bd4fa5c`](https://github.com/NixOS/nixpkgs/commit/2bd4fa5c662a287e9de78eb8d949f907955600cd) | `` python3Packages.google-cloud-iam-logging: 1.7.0 -> 1.8.0 ``                                       |
| [`9a1af430`](https://github.com/NixOS/nixpkgs/commit/9a1af43091f8f8c0af380e0dd9880455b83294ca) | `` telegram-desktop: fix missing build dependency ``                                                 |
| [`c4270dda`](https://github.com/NixOS/nixpkgs/commit/c4270ddad45f8e2eca22bf87068db4b3fd3ef42b) | `` cp2k: fix build by adding cudaPackages.libcufft ``                                                |
| [`126e4a59`](https://github.com/NixOS/nixpkgs/commit/126e4a5985caf3dd94e989f2c6ed870899025443) | `` snyk: 1.1305.1 -> 1.1305.2 ``                                                                     |
| [`e7420d4a`](https://github.com/NixOS/nixpkgs/commit/e7420d4ab5b30c2b5d01f45b798ba920b4442ffe) | `` kdePackages.plasma-workspace-wallpapers: support all platforms ``                                 |
| [`349cf6da`](https://github.com/NixOS/nixpkgs/commit/349cf6da8662973f5908071b1ee12270c1ee2871) | `` krillinai: 1.4.0 -> 2.1.0 ``                                                                      |
| [`b6e39b21`](https://github.com/NixOS/nixpkgs/commit/b6e39b216d88ce807410f1e05908d9cdbb4afb39) | `` python3Packages.x-transformers: limit openmp threads during tests ``                              |
| [`b1539536`](https://github.com/NixOS/nixpkgs/commit/b153953686370a8dc14231db115b058b137644de) | `` python3Packages.torch-geometric: reduce openmp threads during tests ``                            |
| [`4b623fa2`](https://github.com/NixOS/nixpkgs/commit/4b623fa2b84721dfacfa603a8f4d0489fba954fa) | `` lib.lists.reverseList: avoid subtraction ``                                                       |
| [`3dc7f499`](https://github.com/NixOS/nixpkgs/commit/3dc7f499111b07b86097206d947f2737fab90df0) | `` maintainers: update email and matrix for MysteryBlokHed ``                                        |
| [`4e2f331f`](https://github.com/NixOS/nixpkgs/commit/4e2f331f872ba43e43fc62792ce4c96827fd4c7a) | `` lib.lists.toposort: avoid reversing element causing a cycle ``                                    |
| [`7d2f66c0`](https://github.com/NixOS/nixpkgs/commit/7d2f66c0ad076a35343fce74dec06d289e008367) | `` lib.lists.toposort: avoid extra function calls while recursing ``                                 |
| [`099a322b`](https://github.com/NixOS/nixpkgs/commit/099a322b3a539ecc8876561c8ffd0cbc38e481ca) | `` lib.lists.listDfs: compare to [] instead of checking length ``                                    |
| [`0f096eb2`](https://github.com/NixOS/nixpkgs/commit/0f096eb287273bb5c943cb40178ce9b6c4bba047) | `` lib.lists.flatten: save function call when recursing ``                                           |
| [`986cf9ad`](https://github.com/NixOS/nixpkgs/commit/986cf9adb8cb5a1076b4aee7844fe619eabfda71) | `` lib.lists.init: rewrite to not call `take` ``                                                     |
| [`09b8cbd5`](https://github.com/NixOS/nixpkgs/commit/09b8cbd5d969132436b9e7f19f3e0378f0b0d2b1) | `` lib.lists.dropEnd: rewrite to not use `sublist` ``                                                |
| [`bb3308e0`](https://github.com/NixOS/nixpkgs/commit/bb3308e01eb581dac83f0370c4a0e5ab564799e2) | `` lib.lists.takeEnd: rewrite to not call `sublist` ``                                               |
| [`3621649b`](https://github.com/NixOS/nixpkgs/commit/3621649b191156d757a3a0ec858248dfe926e7cb) | `` lib.lists.drop: rewrite to not call `sublist` ``                                                  |
| [`097288cc`](https://github.com/NixOS/nixpkgs/commit/097288cc6f01f55e3bedd7c67fde5f633e21b11a) | `` lib.lists.take: rewrite to not call `sublist` ``                                                  |
| [`261b8489`](https://github.com/NixOS/nixpkgs/commit/261b8489a08855971e056b3a220db7d8e4cf6883) | `` lib.lists.foldl': avoid builtins lookups ``                                                       |
| [`5b49fbd3`](https://github.com/NixOS/nixpkgs/commit/5b49fbd3cc915688ff5c7132b6a08ffad49ac39c) | `` kiwix-apple: 3.14.0 -> 3.15.1 ``                                                                  |
| [`081bf154`](https://github.com/NixOS/nixpkgs/commit/081bf1547cbb233843ea58b4e5cc25bae12cc00e) | `` python3Packages.tinygrad: disable huggingface test that loads huge model ``                       |
| [`96812882`](https://github.com/NixOS/nixpkgs/commit/968128824b661b32fce994576e072ea1aeaa07b4) | `` libretro.fceumm: 0-unstable-2026-06-15 -> 0-unstable-2026-06-23 ``                                |
| [`6a6b8a21`](https://github.com/NixOS/nixpkgs/commit/6a6b8a210535b2cbc51624c81f201b23656cd706) | `` python3Packages.atproto: 0.0.68 -> 0.0.69 ``                                                      |
| [`94065373`](https://github.com/NixOS/nixpkgs/commit/94065373e762f21ccf77bc24603ce648684ede6b) | `` nerva: 1.26.0 -> 1.29.0 ``                                                                        |
| [`acc1ff0d`](https://github.com/NixOS/nixpkgs/commit/acc1ff0d3fdcf3172ae6fef8bd8cacbe45b272b7) | `` terraform-providers.sacloud_sakuracloud: 2.35.1 -> 2.36.0 ``                                      |
| [`ff92c9d1`](https://github.com/NixOS/nixpkgs/commit/ff92c9d15a51dfe2f01341290b79a22090809dd0) | `` lib.strings.cmakeFeature: beta reduce ``                                                          |
| [`4755ddd1`](https://github.com/NixOS/nixpkgs/commit/4755ddd1262901bc7091595b00bc011a58a3112d) | `` lib.strings.{toSentenceCase,toCamelCase}: don't add context unnecessarily ``                      |
| [`f9c9f70a`](https://github.com/NixOS/nixpkgs/commit/f9c9f70a40a99eccafcf2f5fb408bd2958befa6c) | `` lib.strings.cmakeBool: inline two function calls ``                                               |
| [`184d899c`](https://github.com/NixOS/nixpkgs/commit/184d899ccf450c6584b23ca700a195874c9f53df) | `` lib.strings: remove duplicate cmake and meson assertions ``                                       |
| [`a709ca82`](https://github.com/NixOS/nixpkgs/commit/a709ca8240d4ecd960f282bd3b64ab6256684f41) | `` lib.strings.splitString: compute escaped separator early ``                                       |
| [`447d25b6`](https://github.com/NixOS/nixpkgs/commit/447d25b6fc1b0c1a5b098ca10e06048d12ff6acf) | `` python3Packages.scikit-hep-testdata: 0.6.5 -> 0.6.7 ``                                            |
| [`7d2f7d02`](https://github.com/NixOS/nixpkgs/commit/7d2f7d0266fb0a71b2a2bf12aa1c85940522a173) | `` prow: 0-unstable-2026-06-15 -> 0-unstable-2026-06-24 ``                                           |
| [`31bbdb86`](https://github.com/NixOS/nixpkgs/commit/31bbdb868cfe400183bded6c925b023d9fafcec1) | `` air-formatter: fix build ``                                                                       |
| [`d42a3b44`](https://github.com/NixOS/nixpkgs/commit/d42a3b444542201851dceda45de4243a510bf0f1) | `` python3Packages.flash-attn-4: 4.0.0.beta18 -> 4.0.0.beta19 ``                                     |
| [`fc77c504`](https://github.com/NixOS/nixpkgs/commit/fc77c504209c8552c846dc11ae2c42fe76962685) | `` firewalld: 2.4.2 -> 2.4.3 ``                                                                      |
| [`bc103952`](https://github.com/NixOS/nixpkgs/commit/bc103952675ac15f140fc6311f6f315cddbedc97) | `` lowfi: 2.0.6 -> 2.0.7 ``                                                                          |
| [`5062b8f0`](https://github.com/NixOS/nixpkgs/commit/5062b8f0a05a0beb5ad75f97b4633d1f791fbe76) | `` kodiPackages.youtube: 7.4.3 -> 7.4.4 ``                                                           |
| [`dddb77da`](https://github.com/NixOS/nixpkgs/commit/dddb77da1d12283c65afea2afee20a03a9e022e6) | `` istioctl: 1.30.1 -> 1.30.2 ``                                                                     |
| [`a3e3d4e2`](https://github.com/NixOS/nixpkgs/commit/a3e3d4e22b5c3cf5157aecee35b82617d8289d09) | `` element-{desktop,web}: 1.12.21 -> 1.12.22 ``                                                      |
| [`2b882109`](https://github.com/NixOS/nixpkgs/commit/2b882109c2d968b963b4ad73a3fba3c49d5f050b) | `` clickhouse-lts: 26.3.13.31-lts -> 26.3.15.4-lts ``                                                |
| [`adafb5e1`](https://github.com/NixOS/nixpkgs/commit/adafb5e168d39f1cc44ad6fd669299186de4af3d) | `` mo-viewer: 1.6.1 -> 1.6.2 ``                                                                      |
| [`44fa15d9`](https://github.com/NixOS/nixpkgs/commit/44fa15d9b06dec0224656bf23a68a8e6b3a688c8) | `` librewolf-unwrapped: 152.0.1-2 -> 152.0.2-1 ``                                                    |
| [`9d6d8419`](https://github.com/NixOS/nixpkgs/commit/9d6d84196363eed9312ce265b6c3b79c5cca72f3) | `` stalwart-cli: 1.0.8 -> 1.0.9 ``                                                                   |
| [`35ddbee0`](https://github.com/NixOS/nixpkgs/commit/35ddbee063a8259ba451faebd306e512d65b6dcb) | `` rucola: 0.9.0 -> 0.10.0 ``                                                                        |
| [`53754ac6`](https://github.com/NixOS/nixpkgs/commit/53754ac643cbd3d1d69a19f020a43216e3e32cd3) | `` smtprelay: 1.13.3 -> 1.14.0 ``                                                                    |
| [`02b60636`](https://github.com/NixOS/nixpkgs/commit/02b60636282ec042ec78880ed1ef492dd471c40e) | `` stellarsolver: 2.7 -> 2.8 ``                                                                      |
| [`ddd9cfa1`](https://github.com/NixOS/nixpkgs/commit/ddd9cfa12061f2c9ec5867df9f0d366b1cd85a5b) | `` yara-x: 1.18.0 -> 1.19.0 ``                                                                       |
| [`7b505ffd`](https://github.com/NixOS/nixpkgs/commit/7b505ffd34a87026dafff2e5cb4b4adedf42db69) | `` terraform: 1.15.6 -> 1.15.7 ``                                                                    |
| [`daa11e6f`](https://github.com/NixOS/nixpkgs/commit/daa11e6f1d483e59eecbd7e4e5e955f6b928a865) | `` python3Packages.tinygrad: disable flaky performance test ``                                       |
| [`e42dedf9`](https://github.com/NixOS/nixpkgs/commit/e42dedf9d1e5a83f71a8b3766f1793ea88dd0edd) | `` deno: keep denort in a separate output ``                                                         |
| [`6a63a4ad`](https://github.com/NixOS/nixpkgs/commit/6a63a4ad8b9013d60097680e545b14e60d11eb23) | `` pkgs/*: drop maintenanceship of various packages ``                                               |
| [`03dfff6f`](https://github.com/NixOS/nixpkgs/commit/03dfff6fc20940d24bb63f67f4136762a32fd7c0) | `` ci/owners: add llakala as owner of key stdenv files ``                                            |
| [`92a06e9b`](https://github.com/NixOS/nixpkgs/commit/92a06e9bbaf8bfb8e2e3da9f3cbfa4c546dd1183) | `` ci/owners: add llakala as owner of key lib files ``                                               |
| [`ae6601a6`](https://github.com/NixOS/nixpkgs/commit/ae6601a6c33fa0e3e2d16c25f3a30e1a4e70a4da) | `` chromium: avoid references to original version ``                                                 |
| [`72177a19`](https://github.com/NixOS/nixpkgs/commit/72177a1900f72c1c974ed669c5bb094b0e0c19bc) | `` ci/OWNERS: drop code ownership of various things ``                                               |
| [`68b91ba4`](https://github.com/NixOS/nixpkgs/commit/68b91ba417c1781b0ac707c295b273b12ea861fe) | `` protonplus: 0.5.20 -> 0.5.21 ``                                                                   |
| [`b8957881`](https://github.com/NixOS/nixpkgs/commit/b8957881807e2ca32edd4556affe490f994f3607) | `` python3Packages.knx-frontend: 2026.6.1.213802 -> 2026.6.23.203726 ``                              |
| [`60caeb83`](https://github.com/NixOS/nixpkgs/commit/60caeb8325a4c035747be333bc4ce23e056e399b) | `` docker: 29.5.3 -> 29.6.0 ``                                                                       |
| [`81f15956`](https://github.com/NixOS/nixpkgs/commit/81f1595612eb8beeb813e770091985d26b633f89) | `` sd-switch: 0.6.3 -> 0.6.4 ``                                                                      |
| [`c2da0d5f`](https://github.com/NixOS/nixpkgs/commit/c2da0d5f965e86e10037f29994e9eab0e33a7e0f) | `` numr: 0.5.5 -> 0.6.0 ``                                                                           |
| [`41ebb9d8`](https://github.com/NixOS/nixpkgs/commit/41ebb9d8e1cdfeb700901f2924552f44d26e1b1c) | `` python3Packages.langgraph: disable test w/ a race condition on aarch64-Linux ``                   |
| [`123802e9`](https://github.com/NixOS/nixpkgs/commit/123802e98a94573d0c4be717421426a9456f80e3) | `` meilisearch: 1.47.0 -> 1.48.2 ``                                                                  |
| [`a8313436`](https://github.com/NixOS/nixpkgs/commit/a8313436f893cf65cf58399b350e080ceba87796) | `` gitlab: 18.11.5 -> 18.11.6 ``                                                                     |
| [`87bd1fde`](https://github.com/NixOS/nixpkgs/commit/87bd1fde3ec1e7f8374c6bf2abce23a427c380c7) | `` redumper: 724 -> 726 ``                                                                           |
| [`cb1b4bc0`](https://github.com/NixOS/nixpkgs/commit/cb1b4bc0b5cb27cfa9a1cf6adb4eefcb73efe9d8) | `` blesh: 0.4.0-devel3-unstable-2026-05-28 -> 0.4.0-devel3-unstable-2026-06-21 ``                    |
| [`4ab8515f`](https://github.com/NixOS/nixpkgs/commit/4ab8515f57e195c2bc3127d83619aaecb146ecbc) | `` harper: 2.5.0 -> 2.6.0 ``                                                                         |
| [`475a5100`](https://github.com/NixOS/nixpkgs/commit/475a5100f3b63cb163ed32481b2a6e00c45122c5) | `` sandbox-runtime: 0.0.56 -> 0.0.59 ``                                                              |
| [`adc70fc4`](https://github.com/NixOS/nixpkgs/commit/adc70fc450ba544a10c35389f5071d5861feab6d) | `` home-assistant: backport pyjwt 2.13.0 support ``                                                  |
| [`ae7bf778`](https://github.com/NixOS/nixpkgs/commit/ae7bf7781d30c19bef7429eb583cfeeaddda7ccf) | `` lux-cli: 0.32.0 -> 0.33.3 ``                                                                      |
| [`512bb2bd`](https://github.com/NixOS/nixpkgs/commit/512bb2bdd0379811c18897ddc4f3d20cd8490b90) | `` postgresqlPackages.vectorchord: mark as broken on pg19 ``                                         |
| [`4da9ae33`](https://github.com/NixOS/nixpkgs/commit/4da9ae33dad696d4fe16b2a68fd21aecae09df09) | `` pinchflat: correct esbuild symlink name on Darwin ``                                              |
| [`41c021f7`](https://github.com/NixOS/nixpkgs/commit/41c021f78b93f22f983ee8a54f5533fb68f0da71) | `` postgresqlPackages.vectorchord: rename upstream github owner ``                                   |
| [`5a0b9ad6`](https://github.com/NixOS/nixpkgs/commit/5a0b9ad69038638ebd6d704ab96cd67d74002245) | `` aks-mcp-server: 0.0.18 -> 0.0.19 ``                                                               |
| [`3fb3bd45`](https://github.com/NixOS/nixpkgs/commit/3fb3bd45d91f672da12647b472a2eacb57e1e167) | `` flameshot: 13.3.0 -> 14.0.0 ``                                                                    |
| [`05716045`](https://github.com/NixOS/nixpkgs/commit/05716045a29a257ef9f7eeeec2723352f980dfb0) | `` pkl-lsp: update gradle deps ``                                                                    |
| [`6dff14e9`](https://github.com/NixOS/nixpkgs/commit/6dff14e979f7a09c035350c533e23579a7d3f53e) | `` redo: clarify licenses ``                                                                         |
| [`ce4754c1`](https://github.com/NixOS/nixpkgs/commit/ce4754c1e343504586afc43a859aedef1a32f43a) | `` redo: keep phases adjustable with hooks ``                                                        |
| [`f6279913`](https://github.com/NixOS/nixpkgs/commit/f627991320bb62940b819aa9aba762b17cea90bf) | `` redo: 1.4 -> 1.5 ``                                                                               |
| [`3f6b9fde`](https://github.com/NixOS/nixpkgs/commit/3f6b9fde5ebe2235521ad56743674bb68d0880a8) | `` nextcloudPackages: update ``                                                                      |
| [`d69bec62`](https://github.com/NixOS/nixpkgs/commit/d69bec62c00cba506fa882e20758bc1e30180864) | `` fish: fix fishConfig test for embedded web_config ``                                              |
| [`1260b072`](https://github.com/NixOS/nixpkgs/commit/1260b0727b5458aa7b69ee7cda483a2d5558316d) | `` nixos/fish: extract completion generator from the fish binary ``                                  |
| [`5bb73999`](https://github.com/NixOS/nixpkgs/commit/5bb7399937f1fa712ee686bea2e7359a0cfddd23) | `` fish: 4.7.1 -> 4.8.0 ``                                                                           |
| [`68b5ed67`](https://github.com/NixOS/nixpkgs/commit/68b5ed676715901a2d8542103370693c2d732510) | `` maintainers/matrix: rm inactive people ``                                                         |
| [`4ed9aa9f`](https://github.com/NixOS/nixpkgs/commit/4ed9aa9fd26fb33d66ab59bb814b518317c03e9d) | `` maintainers/matrix: rescope the team ``                                                           |
| [`dbb77388`](https://github.com/NixOS/nixpkgs/commit/dbb77388c90ee297214b3de8167781f931df2507) | `` python3Packages.mace-torch: reduce openmp threads during tests ``                                 |
| [`3f564a20`](https://github.com/NixOS/nixpkgs/commit/3f564a2083e9c3157e868dca23ecab6ace8052c8) | `` mastodon: 4.6.0 -> 4.6.1 ``                                                                       |
| [`3ee0489f`](https://github.com/NixOS/nixpkgs/commit/3ee0489f3e55da9a8aa88d6e72de72e7bb214e6c) | `` layerx: init at 1.5.0 ``                                                                          |
| [`a646a39b`](https://github.com/NixOS/nixpkgs/commit/a646a39bb326a34f3b5123392daed4efe0cd72af) | `` maintainers/matrix: add transcaffeine ``                                                          |
| [`d7ab41af`](https://github.com/NixOS/nixpkgs/commit/d7ab41af3fe3af22b78b7d842964abed1b3e3abf) | `` python3Packages.captum: reduce openmp threads during tests ``                                     |
| [`ea6ff054`](https://github.com/NixOS/nixpkgs/commit/ea6ff05458241307e53629a61f1b711d093c1b97) | `` kodiPackages.jellycon: 1.0.0 -> 1.0.1 ``                                                          |
| [`8152fbe9`](https://github.com/NixOS/nixpkgs/commit/8152fbe97482fd71144d4f3f50aa9c70d01f25c2) | `` jonquil: 0.3.1 -> 0.3.2 ``                                                                        |
| [`694eb2f4`](https://github.com/NixOS/nixpkgs/commit/694eb2f41773f642d79e7e239d9fa808d1609eed) | `` modrinth-app-unwrapped: update gradle deps ``                                                     |
| [`85694931`](https://github.com/NixOS/nixpkgs/commit/85694931a933eb50e3d82db3c1a47da5d5a907c2) | `` signal-cli: update gradle deps ``                                                                 |
| [`3bb7dd8f`](https://github.com/NixOS/nixpkgs/commit/3bb7dd8fe67bb5a963f3e17b7f5195a07e3900b6) | `` pkl: update gradle deps ``                                                                        |
| [`1120ba36`](https://github.com/NixOS/nixpkgs/commit/1120ba36d08e6771288a2f5642a1d5e62d517372) | `` jabref: update gradle deps ``                                                                     |
| [`4ff55b6c`](https://github.com/NixOS/nixpkgs/commit/4ff55b6c1ae85712ef33fe7151f649f349a91b41) | `` keyguard: update gradle deps ``                                                                   |
| [`c38f7e59`](https://github.com/NixOS/nixpkgs/commit/c38f7e59781f8e736a12276713bcdebdc92470bd) | `` freeplane: 1.12.16 -> 1.13.2 ``                                                                   |
| [`29638dde`](https://github.com/NixOS/nixpkgs/commit/29638dde9cd8b339aa6e2cdd93fc4efce84de2aa) | `` gradle_9: use jdk25 ``                                                                            |
| [`40525b52`](https://github.com/NixOS/nixpkgs/commit/40525b5262367a27c085b60f51ab812f487b6527) | `` gradle_9: 9.4.1 -> 9.5.1 ``                                                                       |
| [`1d5fe677`](https://github.com/NixOS/nixpkgs/commit/1d5fe677aaf34eee3e2d310416ac0b2826d80c30) | `` python3Packages.scikit-bio: reduce openmp threads during tests ``                                 |
| [`45e309e3`](https://github.com/NixOS/nixpkgs/commit/45e309e3a389d0e0ab83c180852f6396c11cbcdb) | `` ci/treefmt: enable or-identifier rule ``                                                          |

*... and 2623 more commits (truncated)*